### PR TITLE
User can update the help request task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 4.1'
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'rack-cors', require: 'rack/cors'
+gem 'active_model_serializers'
 
 group :development, :test do
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_model_serializers (0.10.10)
+      actionpack (>= 4.1, < 6.1)
+      activemodel (>= 4.1, < 6.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (6.0.2.2)
       activesupport (= 6.0.2.2)
       globalid (>= 0.3.6)
@@ -60,6 +65,8 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.1)
+    case_transform (0.2)
+      activesupport
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
     coveralls (0.8.23)
@@ -83,6 +90,7 @@ GEM
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     json (2.3.0)
+    jsonapi-renderer (0.2.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -203,6 +211,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers
   bootsnap (>= 1.4.2)
   coveralls
   factory_bot_rails

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -2,6 +2,20 @@ class Api::V1::TasksController < ApplicationController
   def create
     task = Task.create
     task.task_items.create(product_id: params[:product_id])
-    render json: {message: "The product has been added to your request", task_id: task.id}
+    render json: create_json_response(task)
+  end
+
+  def update
+    task = Task.find(params[:id])
+    product = Product.find(params[:product_id])
+    task.task_items.create(product: product)
+    render json: create_json_response(task)
+  end
+
+  private
+
+  def create_json_response(task)
+    json = { task: TaskSerializer.new(task) }
+    json.merge!(message: "The product has been added to your request")
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,3 +1,7 @@
 class Task < ApplicationRecord
     has_many :task_items
+
+    def order_total
+        task_items.joins(:product).sum("products.price")
+    end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,7 +1,7 @@
 class Task < ApplicationRecord
-    has_many :task_items
+  has_many :task_items
 
-    def order_total
-        task_items.joins(:product).sum("products.price")
-    end
+  def order_total
+    task_items.joins(:product).sum("products.price")
+  end
 end

--- a/app/serializers/task_serializer.rb
+++ b/app/serializers/task_serializer.rb
@@ -1,0 +1,14 @@
+class TaskSerializer < ActiveModel::Serializer
+  attributes :id, :products, :total, :order_total
+
+  def products
+    object.task_items.group_by(&:product_id).map do |_key, value|
+      product = value.uniq(&:product_id)[0].product
+      { amount: value.size, name: product.name, total: (value.size * product.price) }
+    end
+	end
+
+  def total
+    object.task_items.joins(:product).sum('products.price')
+  end
+end

--- a/app/serializers/task_serializer.rb
+++ b/app/serializers/task_serializer.rb
@@ -6,9 +6,9 @@ class TaskSerializer < ActiveModel::Serializer
       product = value.uniq(&:product_id)[0].product
       { amount: value.size, name: product.name, total: (value.size * product.price) }
     end
-	end
+  end
 
   def total
-    object.task_items.joins(:product).sum('products.price')
+    object.task_items.joins(:product).sum("products.price")
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :products, only: [:index]
-      resources :tasks, only: [:create]
+      resources :tasks, only: [:create, :update]
     end
   end
 end

--- a/spec/requests/api/v1/products_can_be_added_to_tasks_list_spec.rb
+++ b/spec/requests/api/v1/products_can_be_added_to_tasks_list_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe "Api::V1::TasksController", type: :request do
 
   before do 
     post "/api/v1/tasks", params: {product_id: product_1.id}
+    task_id = (response_json)["task"]["id"]
+    @task = Task.find(task_id)
   end
 
   describe "POST api/v1/tasks" do
@@ -16,39 +18,39 @@ RSpec.describe "Api::V1::TasksController", type: :request do
   end
 
   it "response with task ID" do
-    expect((response_json)["task"]["id"]).to eq task.id
+    expect(response_json["task"]["id"]).to eq @task.id
   end
 
   it "response with task right amount of products" do
-    expect((response_json)["task"]["products"]).to eq 1
+    expect(response_json["task"]["products"][0]["amount"]).to eq 1
   end
 
   it "response with the right total amount" do
-    expect((response_json)["task"]["total"]).to eq 20
+    expect(response_json["task"]["total"]).to eq "20.0"
   end
 end
 
 describe "PUT api/v1/tasks/:id" do
   before do 
-    put "/api/v1/tasks/#{task.id}", params: {product_id: product_2.id}
-    put "/api/v1/tasks/#{task.id}", params: {product_id: product_2.id}
-    put "/api/v1/tasks/#{task.id}", params: {product_id: product_3.id}
+    put "/api/v1/tasks/#{@task.id}", params: {product_id: product_2.id}
+    put "/api/v1/tasks/#{@task.id}", params: {product_id: product_2.id}
+    put "/api/v1/tasks/#{@task.id}", params: {product_id: product_3.id}
   end
 
   it "response with succes message" do
-    expect((response_json)["message"]).to eq "The product has been added to your request"
+    expect(response_json["message"]).to eq "The product has been added to your request"
   end
 
   it "response with task ID" do
-    expect((response_json)["task"]["id"]).to eq task.id
+    expect(response_json["task"]["id"]).to eq @task.id
   end
 
   it "response with task right amount of products" do
-    expect((response_json)["task"]["products"]).to eq 4
+    expect(response_json["task"]["products"][1]["amount"]).to eq 2
   end
 
   it "response with the right total amount" do
-    expect((response_json)["task"]["total"]).to eq 100
+    expect(response_json["task"]["total"]).to eq "90.0"
   end
 end
 

--- a/spec/requests/api/v1/products_can_be_added_to_tasks_list_spec.rb
+++ b/spec/requests/api/v1/products_can_be_added_to_tasks_list_spec.rb
@@ -1,15 +1,55 @@
 require "rails_helper"
 
 RSpec.describe "Api::V1::TasksController", type: :request do
-  let!(:product_1) {create(:product, name: "pasta")}
-  let!(:product_2) {create(:product, name: "eggs")}
-  let!(:product_3) {create(:product, name: "tomatoes")}
+  let!(:product_1) {create(:product, name: "pasta", price: 20)}
+  let!(:product_2) {create(:product, name: "eggs", price: 30)}
+  let!(:product_3) {create(:product, name: "tomatoes", price: 10)}
 
   before do 
     post "/api/v1/tasks", params: {product_id: product_1.id}
   end
 
+  describe "POST api/v1/tasks" do
+
   it "response with succes message" do
-    expect(response_json["message"]).to eq "The product has been added to your request"
+    expect((response_json)["message"]).to eq "The product has been added to your request"
   end
+
+  it "response with task ID" do
+    expect((response_json)["task"]["id"]).to eq task.id
+  end
+
+  it "response with task right amount of products" do
+    expect((response_json)["task"]["products"]).to eq 1
+  end
+
+  it "response with the right total amount" do
+    expect((response_json)["task"]["total"]).to eq 20
+  end
+end
+
+describe "PUT api/v1/tasks/:id" do
+  before do 
+    put "/api/v1/tasks/#{task.id}", params: {product_id: product_2.id}
+    put "/api/v1/tasks/#{task.id}", params: {product_id: product_2.id}
+    put "/api/v1/tasks/#{task.id}", params: {product_id: product_3.id}
+  end
+
+  it "response with succes message" do
+    expect((response_json)["message"]).to eq "The product has been added to your request"
+  end
+
+  it "response with task ID" do
+    expect((response_json)["task"]["id"]).to eq task.id
+  end
+
+  it "response with task right amount of products" do
+    expect((response_json)["task"]["products"]).to eq 4
+  end
+
+  it "response with the right total amount" do
+    expect((response_json)["task"]["total"]).to eq 100
+  end
+end
+
 end


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/172292180)
```
As a person who is requesting for help
in order to create a help task that matches my needs
I would like to be able to update,change and see the total amount of my request
```
## Changes proposed in this pull request:
* Adds serializer for task model
* Adds PUT action to update order
## What I have learned working on this feature:
* Using active model serializer 
## Packages/Gems added
- gem 'active_model_serializers', '~> 0.10.2'
## Screenshots (Only if client side story)