### PR TITLE
User can create a task and confirm it

### DIFF
--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -9,11 +9,11 @@ class Api::V1::TasksController < ApplicationController
     task = Task.find(params[:id])
     if params[:activity]
       task.update_attribute(:confirmed, true)
-      render json: {message: "Your task has been confirmed"}
+      render json: { message: "Your task has been confirmed" }
     else
-    product = Product.find(params[:product_id])
-    task.task_items.create(product: product)
-    render json: create_json_response(task)
+      product = Product.find(params[:product_id])
+      task.task_items.create(product: product)
+      render json: create_json_response(task)
     end
   end
 

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -7,9 +7,14 @@ class Api::V1::TasksController < ApplicationController
 
   def update
     task = Task.find(params[:id])
+    if params[:activity]
+      task.update_attribute(:confirmed, true)
+      render json: {message: "Your task has been confirmed"}
+    else
     product = Product.find(params[:product_id])
     task.task_items.create(product: product)
     render json: create_json_response(task)
+    end
   end
 
   private

--- a/db/migrate/20200414092211_add_confirm_task.rb
+++ b/db/migrate/20200414092211_add_confirm_task.rb
@@ -1,0 +1,5 @@
+class AddConfirmTask < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tasks, :confirmed, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_13_120753) do
+ActiveRecord::Schema.define(version: 2020_04_14_092211) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 2020_04_13_120753) do
   create_table "tasks", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "confirmed", default: false
   end
 
   add_foreign_key "task_items", "products"

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,5 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Task, type: :model do
+  describe "Database table" do
+    it { is_expected.to have_db_column :confirmed }
+  end
+  
   it { is_expected.to have_many :task_items }
 end
+

--- a/spec/requests/api/v1/user_can_confirm_task_spec.rb
+++ b/spec/requests/api/v1/user_can_confirm_task_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::TasksController", type: :request do
+  let!(:product_1) { create(:product, name: "pasta", price: 20) }
+  let!(:product_2) { create(:product, name: "eggs", price: 30) }
+  let!(:product_3) { create(:product, name: "tomatoes", price: 10) }
+
+  before do
+    post "/api/v1/tasks", params: { product_id: product_1.id }
+    task_id = (response_json)["task"]["id"]
+    @task = Task.find(task_id)
+  end
+
+  describe "PUT api/v1/tasks/:id" do
+    before do
+      put "/api/v1/tasks/#{@task.id}", params: { product_id: product_2.id }
+      put "/api/v1/tasks/#{@task.id}", params: { product_id: product_3.id }
+      put "/api/v1/tasks/#{@task.id}", params: { activity: "confirmed" }
+    end
+
+    it "response with success message" do
+      expect(response_json["message"]).to eq "Your task has been confirmed"
+    end
+
+    it "sets task attribute confirmed to true" do
+      expect(@task.reload.confirmed).to eq true
+    end
+  end
+end


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/172275166)
```
As a person in need
To be able to get some help
I would like to be able add a task that someone else can help me with
```
## Changes proposed in this pull request:
* Adds "confirm task" table to task model
* Updates the PUT method
## What I have learned working on this feature:
* Adding a table to an existing model
