### PR TITLE
Backend - User can register  

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,4 +25,5 @@ group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'devise_token_auth'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'puma', '~> 4.1'
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'rack-cors', require: 'rack/cors'
 gem 'active_model_serializers'
+gem 'devise_token_auth'
 
 group :development, :test do
   gem 'rspec-rails'
@@ -25,5 +26,4 @@ group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'devise_token_auth'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2)
+    bcrypt (3.1.13)
     bootsnap (1.4.6)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -76,6 +77,16 @@ GEM
       thor (>= 0.19.4, < 2.0)
       tins (~> 1.6)
     crass (1.0.6)
+    devise (4.7.1)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0)
+      responders
+      warden (~> 1.2.3)
+    devise_token_auth (1.1.3)
+      bcrypt (~> 3.0)
+      devise (> 3.5.2, < 5)
+      rails (>= 4.2.0, < 6.1)
     diff-lcs (1.3)
     docile (1.3.2)
     erubi (1.9.0)
@@ -111,6 +122,7 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
+    orm_adapter (0.5.0)
     pg (1.2.3)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -157,6 +169,9 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    responders (3.0.0)
+      actionpack (>= 5.0)
+      railties (>= 5.0)
     rspec-core (3.9.1)
       rspec-support (~> 3.9.1)
     rspec-expectations (3.9.1)
@@ -202,6 +217,8 @@ GEM
       sync
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
+    warden (1.2.8)
+      rack (>= 2.0.6)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
@@ -214,6 +231,7 @@ DEPENDENCIES
   active_model_serializers
   bootsnap (>= 1.4.2)
   coveralls
+  devise_token_auth
   factory_bot_rails
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::API
+        include DeviseTokenAuth::Concerns::SetUserByToken
   include ActionController::Serialization
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class User < ActiveRecord::Base
+  extend Devise::Models
+    # Include default devise modules.
+
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :trackable, :validatable
+  include DeviseTokenAuth::Concerns::User
+end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+DeviseTokenAuth.setup do |config|
+  # By default the authorization headers will change after each request. The
+  # client is responsible for keeping track of the changing tokens. Change
+  # this to false to prevent the Authorization header from changing after
+  # each request.
+  # config.change_headers_on_each_request = true
+
+  # By default, users will need to re-authenticate after 2 weeks. This setting
+  # determines how long tokens will remain valid after they are issued.
+  # config.token_lifespan = 2.weeks
+
+  # Limiting the token_cost to just 4 in testing will increase the performance of
+  # your test suite dramatically. The possible cost value is within range from 4
+  # to 31. It is recommended to not use a value more than 10 in other environments.
+  config.token_cost = Rails.env.test? ? 4 : 10
+
+  # Sets the max number of concurrent devices per user, which is 10 by default.
+  # After this limit is reached, the oldest tokens will be removed.
+  # config.max_number_of_devices = 10
+
+  # Sometimes it's necessary to make several requests to the API at the same
+  # time. In this case, each request in the batch will need to share the same
+  # auth token. This setting determines how far apart the requests can be while
+  # still using the same auth token.
+  # config.batch_request_buffer_throttle = 5.seconds
+
+  # This route will be the prefix for all oauth2 redirect callbacks. For
+  # example, using the default '/omniauth', the github oauth2 provider will
+  # redirect successful authentications to '/omniauth/github/callback'
+  # config.omniauth_prefix = "/omniauth"
+
+  # By default sending current password is not needed for the password update.
+  # Uncomment to enforce current_password param to be checked before all
+  # attribute updates. Set it to :password if you want it to be checked only if
+  # password is updated.
+  # config.check_current_password_before_update = :attributes
+
+  # By default we will use callbacks for single omniauth.
+  # It depends on fields like email, provider and uid.
+  # config.default_callbacks = true
+
+  # Makes it possible to change the headers names
+  # config.headers_names = {:'access-token' => 'access-token',
+  #                        :'client' => 'client',
+  #                        :'expiry' => 'expiry',
+  #                        :'uid' => 'uid',
+  #                        :'token-type' => 'token-type' }
+
+  # By default, only Bearer Token authentication is implemented out of the box.
+  # If, however, you wish to integrate with legacy Devise authentication, you can
+  # do so by enabling this flag. NOTE: This feature is highly experimental!
+  # config.enable_standard_devise_support = false
+end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -1,55 +1,7 @@
 # frozen_string_literal: true
 
 DeviseTokenAuth.setup do |config|
-  # By default the authorization headers will change after each request. The
-  # client is responsible for keeping track of the changing tokens. Change
-  # this to false to prevent the Authorization header from changing after
-  # each request.
-  # config.change_headers_on_each_request = true
-
-  # By default, users will need to re-authenticate after 2 weeks. This setting
-  # determines how long tokens will remain valid after they are issued.
-  # config.token_lifespan = 2.weeks
-
-  # Limiting the token_cost to just 4 in testing will increase the performance of
-  # your test suite dramatically. The possible cost value is within range from 4
-  # to 31. It is recommended to not use a value more than 10 in other environments.
-  config.token_cost = Rails.env.test? ? 4 : 10
-
-  # Sets the max number of concurrent devices per user, which is 10 by default.
-  # After this limit is reached, the oldest tokens will be removed.
-  # config.max_number_of_devices = 10
-
-  # Sometimes it's necessary to make several requests to the API at the same
-  # time. In this case, each request in the batch will need to share the same
-  # auth token. This setting determines how far apart the requests can be while
-  # still using the same auth token.
-  # config.batch_request_buffer_throttle = 5.seconds
-
-  # This route will be the prefix for all oauth2 redirect callbacks. For
-  # example, using the default '/omniauth', the github oauth2 provider will
-  # redirect successful authentications to '/omniauth/github/callback'
-  # config.omniauth_prefix = "/omniauth"
-
-  # By default sending current password is not needed for the password update.
-  # Uncomment to enforce current_password param to be checked before all
-  # attribute updates. Set it to :password if you want it to be checked only if
-  # password is updated.
-  # config.check_current_password_before_update = :attributes
-
-  # By default we will use callbacks for single omniauth.
-  # It depends on fields like email, provider and uid.
-  # config.default_callbacks = true
-
-  # Makes it possible to change the headers names
-  # config.headers_names = {:'access-token' => 'access-token',
-  #                        :'client' => 'client',
-  #                        :'expiry' => 'expiry',
-  #                        :'uid' => 'uid',
-  #                        :'token-type' => 'token-type' }
-
-  # By default, only Bearer Token authentication is implemented out of the box.
-  # If, however, you wish to integrate with legacy Devise authentication, you can
-  # do so by enabling this flag. NOTE: This feature is highly experimental!
-  # config.enable_standard_devise_support = false
+  config.change_headers_on_each_request = false
+  config.token_lifespan = 2.weeks
+  config.batch_request_buffer_throttle = 5.seconds
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  mount_devise_token_auth_for 'User', at: 'api/v1/auth', skip: [:omniauth_callbacks]
   namespace :api do
     namespace :v1 do
       resources :products, only: [:index]

--- a/db/migrate/20200415092538_devise_token_auth_create_users.rb
+++ b/db/migrate/20200415092538_devise_token_auth_create_users.rb
@@ -1,0 +1,58 @@
+class DeviseTokenAuthCreateUsers < ActiveRecord::Migration[6.0]
+  def change
+    create_table(:users) do |t|
+      ## Required
+      t.string :provider, :null => false, :default => "email"
+      t.string :uid, :null => false, :default => ""
+
+      ## Database authenticatable
+      t.string :encrypted_password, :null => false, :default => ""
+
+      ## Recoverable
+      t.string :reset_password_token
+      t.datetime :reset_password_sent_at
+      t.boolean :allow_password_change, :default => false
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Confirmable
+      t.string :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.string :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, :default => 0, :null => false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+      ## User Info
+      t.string :name
+      t.string :role
+      t.string :image
+      t.string :email
+      t.string :address
+      t.integer :postcode
+      t.string :city
+
+      ## Tokens
+      t.json :tokens
+
+      t.timestamps
+
+      ## The columns we want to add
+      t.integer :sign_in_count, default: 0
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.string :current_sign_in_ip
+      t.string :last_sign_in_ip
+    end
+
+    add_index :users, :email, unique: true
+    add_index :users, [:uid, :provider], unique: true
+    add_index :users, :reset_password_token, unique: true
+    add_index :users, :confirmation_token, unique: true
+    # add_index :users, :unlock_token,       unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_14_092211) do
+ActiveRecord::Schema.define(version: 2020_04_15_092538) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,39 @@ ActiveRecord::Schema.define(version: 2020_04_14_092211) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "confirmed", default: false
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "provider", default: "email", null: false
+    t.string "uid", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.boolean "allow_password_change", default: false
+    t.datetime "remember_created_at"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.string "name"
+    t.string "role"
+    t.string "image"
+    t.string "email"
+    t.string "address"
+    t.integer "postcode"
+    t.string "city"
+    t.json "tokens"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.integer "sign_in_count", default: 0
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
   add_foreign_key "task_items", "products"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user do
+    email { "user@mail.com" }
+    password { "password" }
+    password_confirmation { "password" }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe User, type: :model do
+  it "should have valid Factory" do
+    expect(create(:user)).to be_valid
+  end
+
+  describe "Database table" do
+    it { is_expected.to have_db_column :encrypted_password }
+    it { is_expected.to have_db_column :email }
+    it { is_expected.to have_db_column :tokens }
+  end
+
+  describe "Validations" do
+    it { is_expected.to validate_presence_of :email }
+    it { is_expected.to validate_confirmation_of :password }
+
+    context "should not have an invalid email address" do
+      emails = ["asdf@ ds.com", "@example.com", "test me @yahoo.com",
+                "asdf@example", "ddd@.d. .d", "ddd@.d"]
+
+      emails.each do |email|
+        it { is_expected.not_to allow_value(email).for(:email) }
+      end
+    end
+
+    context "should have a valid email address" do
+      emails = ["asdf@ds.com", "hello@example.uk", "test1234@yahoo.si",
+                "asdf@example.eu"]
+
+      emails.each do |email|
+        it { is_expected.to allow_value(email).for(:email) }
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,8 +1,8 @@
 require  'coveralls'
 Coveralls.wear_merged!('rails')
-require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
+
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'

--- a/spec/requests/api/v1/registrations_spec.rb
+++ b/spec/requests/api/v1/registrations_spec.rb
@@ -1,0 +1,87 @@
+RSpec.describe 'POST /api/v1/auth', type: :request do
+    let(:headers) { { HTTP_ACCEPT: 'application/json' } }
+  
+    describe 'with valid credentials' do
+      before do
+        post '/api/v1/auth',
+            params: {
+              email: 'example@craftacademy.se',
+              password: 'password',
+              password_confirmation: 'password'
+            },
+            headers: headers
+      end
+  
+      it 'returns a 200 response status' do
+        expect(response).to have_http_status 200
+      end
+  
+      it 'returns a success message' do
+        expect(response_json['status']).to eq 'success'
+      end
+    end
+  
+    context 'when a user submits' do
+      describe 'a non-matching password confirmation' do
+        before do
+          post '/api/v1/auth',
+              params: {
+                email: 'example@craftacademy.se',
+                password: 'password',
+                password_confirmation: 'wrong_password'
+              },
+              headers: headers
+        end
+  
+        it 'returns a 422 response status' do
+          expect(response).to have_http_status 422
+        end
+  
+        it 'returns an error message' do
+          expect(response_json['errors']['password_confirmation']).to eq ["doesn't match Password"]
+        end
+      end
+  
+      describe 'an invalid email address' do
+        before do
+          post '/api/v1/auth',
+              params: {
+                email: 'example@craft',
+                password: 'password',
+                password_confirmation: 'password'
+              },
+              headers: headers
+        end
+  
+        it 'returns a 422 response status' do
+          expect(response).to have_http_status 422
+        end
+  
+        it 'returns an error message' do
+          expect(response_json['errors']['email']).to eq ['is not an email']
+        end
+      end
+  
+      describe 'an already registered email' do
+        let!(:registered_user) { create(:user, email: 'coach@craftacademy.se') }
+  
+        before do
+          post '/api/v1/auth',
+              params: {
+                email: 'coach@craftacademy.se',
+                password: 'password',
+                password_confirmation: 'password'
+              },
+              headers: headers
+        end
+  
+        it 'returns a 422 response status' do
+          expect(response).to have_http_status 422
+        end
+  
+        it 'returns an error message' do
+          expect(response_json['errors']['email']).to eq ['has already been taken']
+        end
+      end
+    end
+  end


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/172275074)
```
As an User
To be able to use the site
I would like to be able to register
```
## Changes proposed in this pull request:
* Adds registetration functionality
* Installs devise token auth
## What I have learned working on this feature:
* Refreshed registration functionality procedure
* Refreshed knowledge about implementing and testing Devise Token Auth
## Packages/Gems added
- gem 'devise_token_auth'

## Screenshots (Only if client side story)