### PR TITLE
API - Add lat and long to task create and index

### DIFF
--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::TasksController < ApplicationController
   end
 
   def create
-    task = Task.create(user_id: params[:user_id])
+    task = Task.create(task_params)
     task.task_items.create(product_id: params[:product_id])
     render json: create_json_response(task)
   end
@@ -41,6 +41,10 @@ class Api::V1::TasksController < ApplicationController
   end
 
   private
+
+  def task_params
+    params.permit(:id, :products, :total, :long, :lat, :user_id)
+  end
 
   def find_task
     @task = Task.find(params[:id])

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::TasksController < ApplicationController
   before_action :find_task, only: :update
 
   def index
-    tasks = Task.where(status: :confirmed)
+    tasks = Task.where(status: :confirmed || :claimed)
     render json: tasks
   end
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,8 +1,12 @@
+# frozen_string_literal: true
+
 class Task < ApplicationRecord
+  validates_presence_of :status, :long, :lat
+
   has_many :task_items
   belongs_to :user
-  belongs_to :provider, class_name: "User", foreign_key: "provider_id", optional: true
-  enum status: [:pending, :confirmed, :claimed, :finalized]
+  belongs_to :provider, class_name: 'User', foreign_key: 'provider_id', optional: true
+  enum status: %i[pending confirmed claimed finalized]
 
   def is_confirmable?
     task_items.count < 40 && task_items.count >= 5

--- a/app/serializers/task_serializer.rb
+++ b/app/serializers/task_serializer.rb
@@ -1,5 +1,5 @@
 class TaskSerializer < ActiveModel::Serializer
-  attributes :id, :products, :total 
+  attributes :id, :products, :total, :long, :lat 
   belongs_to :user, serializer: UserSerializer
 
   def products

--- a/db/migrate/20200418150325_add_coordinates_to_task.rb
+++ b/db/migrate/20200418150325_add_coordinates_to_task.rb
@@ -1,0 +1,6 @@
+class AddCoordinatesToTask < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tasks, :long, :decimal
+    add_column :tasks, :lat, :decimal
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_18_075524) do
+ActiveRecord::Schema.define(version: 2020_04_18_150325) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,8 @@ ActiveRecord::Schema.define(version: 2020_04_18_075524) do
     t.bigint "user_id", null: false
     t.integer "status", default: 0
     t.bigint "provider_id"
+    t.decimal "long"
+    t.decimal "lat"
     t.index ["provider_id"], name: "index_tasks_on_provider_id"
     t.index ["user_id"], name: "index_tasks_on_user_id"
   end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,6 +1,8 @@
 FactoryBot.define do
   factory :task do
+    user 
+    long { '52.15'}
+    lat{ '52.15'}
     status {'pending'}
-    user
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,21 +1,25 @@
-require 'rails_helper'
+# frozen_string_literal: true
 
 RSpec.describe Task, type: :model do
-
-  it "should have valid factory" do
+  it 'should have valid factory' do
     expect(create(:task)).to be_valid
   end
-  
-  describe "Database table" do
+
+  describe 'Database table' do
     it { is_expected.to have_db_column :status }
     it { is_expected.to have_db_column :provider_id }
     it { is_expected.to have_db_column :long }
     it { is_expected.to have_db_column :lat }
   end
-  
-  it { is_expected.to have_many :task_items }
-  it { is_expected.to belong_to :user }
-  it { is_expected.to belong_to(:provider).optional(true)}
 
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of :lat }
+    it { is_expected.to validate_presence_of :long }
+  end
+
+  describe 'Associations' do
+    it { is_expected.to have_many :task_items }
+    it { is_expected.to belong_to :user }
+    it { is_expected.to belong_to(:provider).optional(true) }
+  end
 end
-

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe Task, type: :model do
   describe "Database table" do
     it { is_expected.to have_db_column :status }
     it { is_expected.to have_db_column :provider_id }
+    it { is_expected.to have_db_column :long }
+    it { is_expected.to have_db_column :lat }
   end
   
   it { is_expected.to have_many :task_items }

--- a/spec/requests/api/v1/requester/user_creates_task_spec.rb
+++ b/spec/requests/api/v1/requester/user_creates_task_spec.rb
@@ -60,10 +60,9 @@ RSpec.describe 'Api::V1::TasksController', type: :request do
       end
 
       it 'response contains long and lat' do
-        expect(response_json['task']['long']).to eq 25.76
-        expect(response_json['task']['lat']).to eq 80.19
+        expect(response_json['task']['long']).to eq "80.19"
+        expect(response_json['task']['lat']).to eq "25.76"
       end
-
     end
   end
 

--- a/spec/requests/api/v1/requester/user_creates_task_spec.rb
+++ b/spec/requests/api/v1/requester/user_creates_task_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe 'Api::V1::TasksController', type: :request do
       post '/api/v1/tasks',
            params: {
              product_id: product_1.id,
-             user_id: user.id
+             user_id: user.id,
+             lat: 25.76,
+             long: 80.19
            },
            headers: user_headers
       task_id = response_json['task']['id']
@@ -56,6 +58,12 @@ RSpec.describe 'Api::V1::TasksController', type: :request do
       it 'response with the right total amount' do
         expect(response_json['task']['total']).to eq '110.0'
       end
+
+      it 'response contains long and lat' do
+        expect(response_json['task']['long']).to eq 25.76
+        expect(response_json['task']['lat']).to eq 80.19
+      end
+
     end
   end
 


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/166150770)
```
As Helper
In order to know who to help and where
I want to see their icon in the google maps.
```
## Changes proposed in this pull request:
* Adds unit test for Lat and long columns 
* Adds lat & long columns in the task table
* Validates task models fields
* Extends the Show actions to requests that are being claimed
## What I have learned working on this feature:
* refreshed knowledge on adding columns to a table
