### PR TITLE
Volunteer/provider can set his task as delivered

### DIFF
--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -32,6 +32,13 @@ class Api::V1::TasksController < ApplicationController
       else
         render_error_message(@task)
       end
+    when 'delivered'
+      if @task.is_deliverable?(current_user)
+        @task.update(status: params[:activity], provider: current_user)
+        render json: { message: 'Thank you for your help!' }
+      else
+        render_error_message(@task)
+      end
     else
       product = Product.find(params[:product_id])
       @task.task_items.create(product: product)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,6 +22,9 @@ class ApplicationController < ActionController::API
     elsif params[:activity] == "claimed"
       message = "The task has already been claimed!"
       request_status = 409
+    elsif params[:activity] == "delivered"
+      message = "You haven't claimed this task, please contact support."
+      request_status = 401
     else
       message = "We are experiencing internal errors. Please refresh the page and contact support. No activity specified"
       request_status = 500

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -15,4 +15,8 @@ class Task < ApplicationRecord
   def is_claimable?(user)
     status != 'claimed' && self.user != user
   end
+
+  def is_deliverable?(user)
+    status != 'delivered' && self.user != user
+  end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -17,6 +17,6 @@ class Task < ApplicationRecord
   end
 
   def is_deliverable?(user)
-    status != 'delivered' && self.user != user
+    status != 'delivered' && self.provider == user
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -6,7 +6,7 @@ class Task < ApplicationRecord
   has_many :task_items
   belongs_to :user
   belongs_to :provider, class_name: 'User', foreign_key: 'provider_id', optional: true
-  enum status: %i[pending confirmed claimed finalized]
+  enum status: %i[pending confirmed claimed delivered]
 
   def is_confirmable?
     task_items.count < 40 && task_items.count >= 5

--- a/spec/requests/api/v1/provider/deliver_task_spec.rb
+++ b/spec/requests/api/v1/provider/deliver_task_spec.rb
@@ -3,10 +3,10 @@ RSpec.describe "PUT api/v1/tasks/:id", type: :request do
   let(:provider_credentials) { provider.create_new_auth_token }
   let(:provider_headers) { { HTTP_ACCEPT: "application/json" }.merge!(provider_credentials) }
 
-  let(:task) { create(:task, status: "claimed") }
+  let(:task) { create(:task, status: "claimed", provider: provider) }
   let!(:task_items) { 5.times { create(:task_item, task: task) } }
 
-  describe "Succesfully claims task" do
+  describe "Succesfully delivers task" do
     before do
       put "/api/v1/tasks/#{task.id}",
           params: { activity: "delivered" },
@@ -14,6 +14,7 @@ RSpec.describe "PUT api/v1/tasks/:id", type: :request do
     end
 
     it "returns a 200 response status" do
+      binding.pry
       expect(response).to have_http_status 200
     end
 

--- a/spec/requests/api/v1/provider/deliver_task_spec.rb
+++ b/spec/requests/api/v1/provider/deliver_task_spec.rb
@@ -1,25 +1,48 @@
-RSpec.describe "PUT api/v1/tasks/:id", type: :request do
+# frozen_string_literal: true
+
+RSpec.describe 'PUT api/v1/tasks/:id', type: :request do
   let(:provider) { create(:user) }
   let(:provider_credentials) { provider.create_new_auth_token }
-  let(:provider_headers) { { HTTP_ACCEPT: "application/json" }.merge!(provider_credentials) }
+  let(:provider_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(provider_credentials) }
 
-  let(:task) { create(:task, status: "claimed", provider: provider) }
+  let(:task) { create(:task, status: 'claimed', provider: provider) }
   let!(:task_items) { 5.times { create(:task_item, task: task) } }
 
-  describe "Succesfully delivers task" do
+  describe 'Succesfully delivers task' do
     before do
       put "/api/v1/tasks/#{task.id}",
-          params: { activity: "delivered" },
+          params: { activity: 'delivered' },
           headers: provider_headers
     end
 
-    it "returns a 200 response status" do
-      binding.pry
+    it 'returns a 200 response status' do
       expect(response).to have_http_status 200
     end
 
-    it "response with success message" do
-      expect(response_json["message"]).to eq "Thank you for your help!"
+    it 'response with success message' do
+      expect(response_json['message']).to eq 'Thank you for your help!'
+    end
+  end
+
+  describe 'Unsuccesfully delivers task' do
+    let(:another_provider) { create(:user) }
+    let(:another_provider_credentials) { another_provider.create_new_auth_token }
+    let(:another_provider_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(another_provider_credentials) }
+
+    describe 'Another provider tries to deliver task' do
+      before do
+        put "/api/v1/tasks/#{task.id}",
+            params: { activity: 'delivered' },
+            headers: another_provider_headers
+      end
+
+      it 'returns a 400 response status' do
+        expect(response).to have_http_status 401
+      end
+
+      it 'response with unauthorized message' do
+        expect(response_json['error_message']).to eq "You haven't claimed this task, please contact support."
+      end
     end
   end
 end

--- a/spec/requests/api/v1/provider/deliver_task_spec.rb
+++ b/spec/requests/api/v1/provider/deliver_task_spec.rb
@@ -1,47 +1,47 @@
 # frozen_string_literal: true
 
-RSpec.describe 'PUT api/v1/tasks/:id', type: :request do
+RSpec.describe "PUT api/v1/tasks/:id", type: :request do
   let(:provider) { create(:user) }
   let(:provider_credentials) { provider.create_new_auth_token }
-  let(:provider_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(provider_credentials) }
+  let(:provider_headers) { { HTTP_ACCEPT: "application/json" }.merge!(provider_credentials) }
 
-  let(:task) { create(:task, status: 'claimed', provider: provider) }
+  let(:task) { create(:task, status: "claimed", provider: provider) }
   let!(:task_items) { 5.times { create(:task_item, task: task) } }
 
-  describe 'Succesfully delivers task' do
+  describe "Succesfully delivers task" do
     before do
       put "/api/v1/tasks/#{task.id}",
-          params: { activity: 'delivered' },
-          headers: provider_headers
+        params: { activity: "delivered" },
+        headers: provider_headers
     end
 
-    it 'returns a 200 response status' do
+    it "returns a 200 response status" do
       expect(response).to have_http_status 200
     end
 
-    it 'response with success message' do
-      expect(response_json['message']).to eq 'Thank you for your help!'
+    it "response with success message" do
+      expect(response_json["message"]).to eq "Thank you for your help!"
     end
   end
 
-  describe 'Unsuccesfully delivers task' do
+  describe "Unsuccesfully delivers task" do
     let(:another_provider) { create(:user) }
     let(:another_provider_credentials) { another_provider.create_new_auth_token }
-    let(:another_provider_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(another_provider_credentials) }
+    let(:another_provider_headers) { { HTTP_ACCEPT: "application/json" }.merge!(another_provider_credentials) }
 
-    describe 'Another provider tries to deliver task' do
+    describe "Another provider tries to deliver task" do
       before do
         put "/api/v1/tasks/#{task.id}",
-            params: { activity: 'delivered' },
-            headers: another_provider_headers
+          params: { activity: "delivered" },
+          headers: another_provider_headers
       end
 
-      it 'returns a 400 response status' do
+      it "returns a 400 response status" do
         expect(response).to have_http_status 401
       end
 
-      it 'response with unauthorized message' do
-        expect(response_json['error_message']).to eq "You haven't claimed this task, please contact support."
+      it "response with unauthorized message" do
+        expect(response_json["error_message"]).to eq "You haven't claimed this task, please contact support."
       end
     end
   end

--- a/spec/requests/api/v1/provider/deliver_task_spec.rb
+++ b/spec/requests/api/v1/provider/deliver_task_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe "PUT api/v1/tasks/:id", type: :request do
+  let(:provider) { create(:user) }
+  let(:provider_credentials) { provider.create_new_auth_token }
+  let(:provider_headers) { { HTTP_ACCEPT: "application/json" }.merge!(provider_credentials) }
+
+  let(:task) { create(:task, status: "claimed") }
+  let!(:task_items) { 5.times { create(:task_item, task: task) } }
+
+  describe "Succesfully claims task" do
+    before do
+      put "/api/v1/tasks/#{task.id}",
+          params: { activity: "delivered" },
+          headers: provider_headers
+    end
+
+    it "returns a 200 response status" do
+      expect(response).to have_http_status 200
+    end
+
+    it "response with success message" do
+      expect(response_json["message"]).to eq "Thank you for your help!"
+    end
+  end
+end


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/172396261)

```
As a Volunteer/provider
When I deliver the task to a person in need of help
I would like to be able to mark the task as delivered.
```

## Changes proposed in this pull request:

* Adds Enum delivered to TASK
* Added the following sad paths:
- Another provider cannot deliver your claimed task.

## What I have learned working on this feature:

* Modifying task model with Enum and new function.
* Refreshed knowledge about rails Enums.