### PR TITLE
API - Helper can decline services.

### DIFF
--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -8,4 +8,24 @@ class Api::V1::ProfilesController < ApplicationController
     created_tasks = current_user.tasks.empty? ? "You don't have any ongoing tasks." : current_user.tasks
     render json: { claimed_tasks: claimed_tasks, created_tasks: created_tasks }
   end
+
+  def update
+    task = Task.find(params[:id])
+  if params[:activity]
+      task.update_attributes(status: "confirmed")
+      render json: { message: "Your claimed task has been declined" }
+      binding.pry
+    end
+  end
+
+  private
+
+  def search_user
+  end
 end
+
+# def create_json_response(task)
+#   json = { task: TaskSerializer.new(task) }
+#   json.merge!(message: "The product has been added to your request")
+# end
+

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -11,21 +11,11 @@ class Api::V1::ProfilesController < ApplicationController
 
   def update
     task = Task.find(params[:id])
-  if params[:activity]
-      task.update_attributes(status: "confirmed")
-      render json: { message: "Your claimed task has been declined" }
-      binding.pry
+    if task.is_declinable?(current_user)
+      task.update(status: params[:activity], provider: current_user)
+      render json: { message: 'Your claimed task has been declined' }
+    else
+      render json: { error_message: 'You are not authorized for this action.' }, status: 401
     end
   end
-
-  private
-
-  def search_user
-  end
 end
-
-# def create_json_response(task)
-#   json = { task: TaskSerializer.new(task) }
-#   json.merge!(message: "The product has been added to your request")
-# end
-

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::ProfilesController < ApplicationController
   def update
     task = Task.find(params[:id])
     if task.is_declinable?(current_user)
-      task.update(status: params[:activity], provider: current_user)
+      task.update(status: params[:activity])
       render json: { message: 'Your claimed task has been declined' }
     else
       render json: { error_message: 'You are not authorized for this action.' }, status: 401

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::TasksController < ApplicationController
     if task.status == "confirmed" || task.status == "claimed"
       render json: task
     else
-      render json: { message: "The task you are searching for does not exist" }, status: 404
+      render json: { message: "The task you are searching for does not exist." }, status: 404
     end
   end
 

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::TasksController < ApplicationController
 
   def show
     task = Task.find(params[:id])
-    if task.status == "confirmed" 
+    if task.status == "confirmed" || task.status == "claimed"
       render json: task
     else
       render json: { message: "The task you are searching for does not exist" }, status: 404

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -23,4 +23,8 @@ class Task < ApplicationRecord
   def is_finalizable?(user)
     status != 'finalized' && self.user == user
   end
+
+  def is_declinable?(user)
+    status == 'claimed' && self.provider == user
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :products, only: [:index]
       resources :tasks, only: [:create, :update, :index, :show]
-      resources :profiles, only: [:index]
+      resources :profiles, only: [:index, :update]
     end
   end
 end

--- a/spec/requests/api/v1/provider/decline_claimed_task_spec.rb
+++ b/spec/requests/api/v1/provider/decline_claimed_task_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe "PUT api/v1/tasks/:id", type: :request do
+  let(:provider) { create(:user) }
+  let(:provider_credentials) { provider.create_new_auth_token }
+  let(:provider_headers) { { HTTP_ACCEPT: "application/json" }.merge!(provider_credentials) }
+
+  let(:task) { create(:task, status: "claimed", user: provider) }
+  let!(:task_items) { 5.times { create(:task_item, task: task) } }
+
+  describe "Succesfully declines a task" do
+    before do
+      put "/api/v1/profiles/#{task.id}",
+          params: { activity: "confirmed" },
+          headers: provider_headers
+    end
+
+    it "response with success message" do
+         expect(response_json["message"]).to eq "Your claimed task has been declined"
+    end
+
+  end
+end

--- a/spec/requests/api/v1/provider/decline_claimed_task_spec.rb
+++ b/spec/requests/api/v1/provider/decline_claimed_task_spec.rb
@@ -1,23 +1,48 @@
 # frozen_string_literal: true
 
-RSpec.describe "PUT api/v1/tasks/:id", type: :request do
+RSpec.describe 'PUT api/v1/tasks/:id', type: :request do
   let(:provider) { create(:user) }
   let(:provider_credentials) { provider.create_new_auth_token }
-  let(:provider_headers) { { HTTP_ACCEPT: "application/json" }.merge!(provider_credentials) }
+  let(:provider_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(provider_credentials) }
 
-  let(:task) { create(:task, status: "claimed", user: provider) }
+  let(:task) { create(:task, status: 'claimed', provider: provider ) }
   let!(:task_items) { 5.times { create(:task_item, task: task) } }
 
-  describe "Succesfully declines a task" do
+  describe 'Succesfully declines a task' do
     before do
       put "/api/v1/profiles/#{task.id}",
-          params: { activity: "confirmed" },
+          params: { activity: 'confirmed' },
           headers: provider_headers
     end
 
-    it "response with success message" do
-         expect(response_json["message"]).to eq "Your claimed task has been declined"
+    it 'returns a 200 response status' do
+      expect(response).to have_http_status 200
     end
 
+    it 'response with success message' do
+      expect(response_json['message']).to eq 'Your claimed task has been declined'
+    end
+  end
+
+  describe 'Unsuccessfully' do
+    let(:another_provider) { create(:user) }
+    let(:another_provider_credentials) { another_provider.create_new_auth_token }
+    let(:another_provider_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(another_provider_credentials) }
+  
+    describe 'Another provider tries to decline a task' do
+      before do
+        put "/api/v1/profiles/#{task.id}",
+            params: { activity: 'confirmed' },
+            headers: another_provider_headers
+      end
+
+      it 'returns a 401 response status' do
+        expect(response).to have_http_status 401
+      end
+
+      it 'response with success message' do
+        expect(response_json['error_message']).to eq 'You are not authorized for this action.'
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/provider/decline_claimed_task_spec.rb
+++ b/spec/requests/api/v1/provider/decline_claimed_task_spec.rb
@@ -40,7 +40,25 @@ RSpec.describe 'PUT api/v1/tasks/:id', type: :request do
         expect(response).to have_http_status 401
       end
 
-      it 'response with success message' do
+      it 'response with error message' do
+        expect(response_json['error_message']).to eq 'You are not authorized for this action.'
+      end
+    end
+
+    describe 'Provider tries to decline a task that is delivered' do
+      let(:delivered_task) { create(:task, status: 'delivered', provider: provider ) }
+
+      before do
+        put "/api/v1/profiles/#{delivered_task.id}",
+            params: { activity: 'confirmed' },
+            headers: provider_headers
+      end
+
+      it 'returns a 401 response status' do
+        expect(response).to have_http_status 401
+      end
+
+      it 'response with error message' do
         expect(response_json['error_message']).to eq 'You are not authorized for this action.'
       end
     end

--- a/spec/requests/api/v1/provider/see_specific_task_spec.rb
+++ b/spec/requests/api/v1/provider/see_specific_task_spec.rb
@@ -1,13 +1,15 @@
+# frozen_string_literal: true
+
 RSpec.describe Api::V1::TasksController, type: :request do
-  
-    describe' GET /task/id successfully' do
+
+  describe 'Successfully' do
+    describe 'Successfully gets specific task that is confirmed' do
       let(:task) { create(:task, status: 'confirmed') }
       let!(:task_items) { 5.times { create(:task_item, task: task) } }
-
       before do
         get "/api/v1/tasks/#{task.id}"
       end
-  
+
       it 'should return a 200 response' do
         expect(response).to have_http_status 200
       end
@@ -20,21 +22,61 @@ RSpec.describe Api::V1::TasksController, type: :request do
         expect(Task.last.status).to eq 'confirmed'
       end
     end
+  end
 
-    describe' GET /task/id unsuccessfully' do
+  describe 'Successfully gets specific task that is claimed' do
+    let(:task) { create(:task, status: 'claimed') }
+    let!(:task_items) { 5.times { create(:task_item, task: task) } }
+    before do
+      get "/api/v1/tasks/#{task.id}"
+    end
+
+    it 'should return a 200 response' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'should return task id' do
+      expect(response_json['id']).to eq task.id
+    end
+
+    it 'should return status' do
+      expect(Task.last.status).to eq 'claimed'
+    end
+  end
+
+  describe 'Unsuccessfully' do
+    describe 'Cannot get task that is delivered' do
       let(:task) { create(:task, status: 'delivered') }
       let!(:task_items) { 5.times { create(:task_item, task: task) } }
 
       before do
         get "/api/v1/tasks/#{task.id}"
       end
-  
+
       it 'should return a 404 response' do
         expect(response).to have_http_status 404
       end
 
       it 'should return task id' do
-        expect(response_json['message']).to eq "The task you are searching for does not exist" 
+        expect(response_json['message']).to eq 'The task you are searching for does not exist.'
       end
     end
-  end 
+
+    describe 'Cannot get task that is finalized' do
+      let(:task) { create(:task, status: 'finalized') }
+      let!(:task_items) { 5.times { create(:task_item, task: task) } }
+
+      before do
+        get "/api/v1/tasks/#{task.id}"
+      end
+
+      it 'should return a 404 response' do
+        expect(response).to have_http_status 404
+      end
+
+      it 'should return task id' do
+        expect(response_json['message']).to eq 'The task you are searching for does not exist.'
+      end
+    end
+  end
+end


### PR DESCRIPTION

# [PT Story](https://www.pivotaltracker.com/story/show/172275927)
```
As a helper
To be able to return a request in case something unforeseen happens
I would like to see and be able to return a request I have previously have claimed
```
## Changes proposed in this pull request:
* Adds update action to decline a previous claimed task
* Adds an update action in the profiles controller
## What I have learned working on this feature:
* Refreshed knowledge about updating
