### PR TITLE
User can delete his request for help.

### DIFF
--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -26,11 +26,11 @@ class Api::V1::TasksController < ApplicationController
   end
 
   def destroy
-    if @task.is_deletable?
+    if @task.is_deletable?(current_user)
       @task.destroy
       render json: { message: 'Your task has been successfully delted' }, status: 200
     else
-      binding.pry
+      render json: { error_message: 'You are not authorized to do this action.' }, status: 401
     end
   end
 

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V1::TasksController < ApplicationController
-  before_action :authenticate_user!, only: %i[create update]
+  before_action :authenticate_user!, only: %i[create update delete]
   before_action :restrict_user_to_have_one_active_task, only: %i[create]
   before_action :find_task, only: :update
 
@@ -24,6 +24,12 @@ class Api::V1::TasksController < ApplicationController
     task.task_items.create(product_id: params[:product_id])
     render json: create_json_response(task)
   end
+
+
+  def destroy 
+    binding.pry
+  end
+
 
   def update
     case params[:activity]

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
 class Api::V1::TasksController < ApplicationController
-  before_action :authenticate_user!, only: %i[create update delete]
+  before_action :authenticate_user!, only: %i[create update destroy]
   before_action :restrict_user_to_have_one_active_task, only: %i[create]
-  before_action :find_task, only: :update
+  before_action :find_task, only: %i[destroy update]
 
   def show
     task = Task.find(params[:id])
-    if task.status == "confirmed" 
+    if task.status == 'confirmed'
       render json: task
     else
-      render json: { message: "The task you are searching for does not exist" }, status: 404
+      render json: { message: 'The task you are searching for does not exist' }, status: 404
     end
   end
 
@@ -25,39 +25,42 @@ class Api::V1::TasksController < ApplicationController
     render json: create_json_response(task)
   end
 
-
-  def destroy 
-    binding.pry
+  def destroy
+    if @task.is_deletable?
+      @task.destroy
+      render json: { message: 'Your task has been successfully delted' }, status: 200
+    else
+      binding.pry
+    end
   end
-
 
   def update
     case params[:activity]
-    when "confirmed"
+    when 'confirmed'
       if @task.is_confirmable?
         @task.update(status: params[:activity])
-        render json: { message: "Your task has been confirmed" }
+        render json: { message: 'Your task has been confirmed' }
       else
         render_error_message(@task)
       end
-    when "claimed"
+    when 'claimed'
       if @task.is_claimable?(current_user)
         @task.update(status: params[:activity], provider: current_user)
-        render json: { message: "You claimed the task" }
+        render json: { message: 'You claimed the task' }
       else
         render_error_message(@task)
       end
-    when "delivered"
+    when 'delivered'
       if @task.is_deliverable?(current_user)
         @task.update(status: params[:activity], provider: current_user)
-        render json: { message: "Thank you for your help!" }
+        render json: { message: 'Thank you for your help!' }
       else
         render_error_message(@task)
       end
-    when "finalized"
+    when 'finalized'
       if @task.is_finalizable?(current_user)
         @task.update(status: params[:activity], user: current_user)
-        render json: { message: "We are happy that you received your order. Please be in touch if you have any further request." }
+        render json: { message: 'We are happy that you received your order. Please be in touch if you have any further request.' }
       else
         render_error_message(@task)
       end
@@ -79,14 +82,14 @@ class Api::V1::TasksController < ApplicationController
   end
 
   def restrict_user_to_have_one_active_task
-    if current_user.tasks.any? { |task| task.status == "confirmed" }
-      render json: { error: "You can only have one active task at a time." }, status: 403
+    if current_user.tasks.any? { |task| task.status == 'confirmed' }
+      render json: { error: 'You can only have one active task at a time.' }, status: 403
       nil
     end
   end
 
   def create_json_response(task)
     json = { task: TaskSerializer.new(task) }
-    json.merge!(message: "The product has been added to your request")
+    json.merge!(message: 'The product has been added to your request')
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,7 +3,7 @@
 class Task < ApplicationRecord
   validates_presence_of :status, :long, :lat
 
-  has_many :task_items
+  has_many :task_items, dependent: :delete_all
   belongs_to :user
   belongs_to :provider, class_name: 'User', foreign_key: 'provider_id', optional: true
   enum status: %i[pending confirmed claimed delivered finalized]
@@ -22,5 +22,9 @@ class Task < ApplicationRecord
 
   def is_finalizable?(user)
     status != 'finalized' && self.user == user
+  end
+
+  def is_deletable?
+    status == 'confirmed' 
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -24,7 +24,7 @@ class Task < ApplicationRecord
     status != 'finalized' && self.user == user
   end
 
-  def is_deletable?
-    status == 'confirmed' 
+  def is_deletable?(user)
+    status == 'confirmed' && self.user == user
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :products, only: [:index]
-      resources :tasks, only: [:create, :update, :index, :show]
+      resources :tasks, only: [:create, :update, :index, :show, :destroy]
       resources :profiles, only: [:index]
     end
   end

--- a/spec/requests/api/v1/requester/delete_task_spec.rb
+++ b/spec/requests/api/v1/requester/delete_task_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::V1.tasksController, type: :request do
+  let(:user) { create(:user) }
+  let(:user_credentials) { user.create_new_auth_token }
+  let(:user_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(user_credentials) }
+
+  let(:task) { create(:task, status: 'delivered', provider: provider, user: user) }
+  let!(:task_items) { 5.times { create(:task_item, task: task) } }
+
+
+  describe 'Successessfully' do
+    describe 'DELETE /api/v1/task/id' do
+      before do
+        delete "/api/v1/tasks/#{task.id}",
+         headers: admin_headers
+      end
+
+      it 'returns a 200 response status' do
+        expect(response).to have_http_status 200
+      end
+  
+      it 'Requester is able to delete his request.' do
+        expect(json_response['message']).to eq 'task successfully deleted'
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/requester/delete_task_spec.rb
+++ b/spec/requests/api/v1/requester/delete_task_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Api::V1::TasksController', type: :request do
   let!(:user_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(user_credentials) }
 
   describe 'Successessfully' do
-    describe 'User can delete his order.' do
+    describe 'User can delete his task.' do
       let!(:task) { create(:task, status: 'confirmed', user: user) }
       let!(:task_items) { 5.times { create(:task_item, task: task) } }
   
@@ -21,6 +21,30 @@ RSpec.describe 'Api::V1::TasksController', type: :request do
   
       it 'Requester is able to delete his request.' do
         expect(response_json['message']).to eq 'Your task has been successfully delted'
+      end
+    end
+  end
+
+  describe 'Unccessessfully' do
+    let!(:another_user) { create(:user) }
+    let!(:another_user_credentials) { another_user.create_new_auth_token }
+    let!(:another_user_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(another_user_credentials) }
+  
+    describe 'User tries to delete  another user request order.' do
+      let!(:task) { create(:task, status: 'confirmed', user: user) }
+      let!(:task_items) { 5.times { create(:task_item, task: task) } }
+  
+      before do
+        delete "/api/v1/tasks/#{task.id}",
+         headers: another_user_headers
+      end
+
+      it 'returns a 401 response status' do
+        expect(response).to have_http_status 401
+      end
+  
+      it 'Requester is able to delete his request.' do
+        expect(response_json['error_message']).to eq 'You are not authorized to do this action.'
       end
     end
   end

--- a/spec/requests/api/v1/requester/delete_task_spec.rb
+++ b/spec/requests/api/v1/requester/delete_task_spec.rb
@@ -1,19 +1,18 @@
 # frozen_string_literal: true
 
-RSpec.describe Api::V1.tasksController, type: :request do
+RSpec.describe 'Api::V1::TasksController', type: :request do
   let(:user) { create(:user) }
   let(:user_credentials) { user.create_new_auth_token }
   let(:user_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(user_credentials) }
 
-  let(:task) { create(:task, status: 'delivered', provider: provider, user: user) }
+  let(:task) { create(:task, status: 'confirmed', user: user) }
   let!(:task_items) { 5.times { create(:task_item, task: task) } }
-
 
   describe 'Successessfully' do
     describe 'DELETE /api/v1/task/id' do
       before do
         delete "/api/v1/tasks/#{task.id}",
-         headers: admin_headers
+         headers: user_headers
       end
 
       it 'returns a 200 response status' do

--- a/spec/requests/api/v1/requester/delete_task_spec.rb
+++ b/spec/requests/api/v1/requester/delete_task_spec.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 RSpec.describe 'Api::V1::TasksController', type: :request do
-  let(:user) { create(:user) }
-  let(:user_credentials) { user.create_new_auth_token }
-  let(:user_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(user_credentials) }
-
-  let(:task) { create(:task, status: 'confirmed', user: user) }
-  let!(:task_items) { 5.times { create(:task_item, task: task) } }
+  let!(:user) { create(:user) }
+  let!(:user_credentials) { user.create_new_auth_token }
+  let!(:user_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(user_credentials) }
 
   describe 'Successessfully' do
-    describe 'DELETE /api/v1/task/id' do
+    describe 'User can delete his order.' do
+      let!(:task) { create(:task, status: 'confirmed', user: user) }
+      let!(:task_items) { 5.times { create(:task_item, task: task) } }
+  
       before do
         delete "/api/v1/tasks/#{task.id}",
          headers: user_headers
@@ -20,7 +20,7 @@ RSpec.describe 'Api::V1::TasksController', type: :request do
       end
   
       it 'Requester is able to delete his request.' do
-        expect(json_response['message']).to eq 'task successfully deleted'
+        expect(response_json['message']).to eq 'Your task has been successfully delted'
       end
     end
   end


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/172275921)
```
As a person in need
To be able to go back and regret asking for help
I would like to be able inactivate or remove my request so nobody can see it anymore
```
## Changes proposed in this pull request:
* Adds destroy action to delete a previous created task

## What I have learned working on this feature:
* Refreshed knowledge about rails destroy main key and their sub-keys
