### PR TITLE
 Users can see the address on the marks.

### DIFF
--- a/app/serializers/task_serializer.rb
+++ b/app/serializers/task_serializer.rb
@@ -1,5 +1,5 @@
 class TaskSerializer < ActiveModel::Serializer
-  attributes :id, :products, :total, :long, :lat, :provider_id
+  attributes :id, :products, :total, :long, :lat, :provider_id, :address
   belongs_to :user, serializer: UserSerializer
 
   def products

--- a/app/serializers/task_serializer.rb
+++ b/app/serializers/task_serializer.rb
@@ -1,5 +1,5 @@
 class TaskSerializer < ActiveModel::Serializer
-  attributes :id, :products, :total, :long, :lat, :provider_id, :address
+  attributes :id, :products, :total, :long, :lat, :provider_id, :address, :name, :phone
   belongs_to :user, serializer: UserSerializer
 
   def products

--- a/db/migrate/20200424053217_add_address_to_tasks.rb
+++ b/db/migrate/20200424053217_add_address_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddAddressToTasks < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tasks, :address, :string
+  end
+end

--- a/db/migrate/20200424053217_add_address_to_tasks.rb
+++ b/db/migrate/20200424053217_add_address_to_tasks.rb
@@ -1,5 +1,7 @@
 class AddAddressToTasks < ActiveRecord::Migration[6.0]
   def change
     add_column :tasks, :address, :string
+    add_column :tasks, :name, :string
+    add_column :tasks, :phone, :string
   end
 end

--- a/db/migrate/20200424053517_remove_multiple_from_user.rb
+++ b/db/migrate/20200424053517_remove_multiple_from_user.rb
@@ -1,0 +1,8 @@
+class RemoveMultipleFromUser < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :users, :role   
+    remove_column :users, :image
+    remove_column :users, :postcode
+    remove_column :users, :city
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -41,6 +41,8 @@ ActiveRecord::Schema.define(version: 2020_04_24_053517) do
     t.decimal "long"
     t.decimal "lat"
     t.string "address"
+    t.string "name"
+    t.string "phone"
     t.index ["provider_id"], name: "index_tasks_on_provider_id"
     t.index ["user_id"], name: "index_tasks_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_21_092625) do
+ActiveRecord::Schema.define(version: 2020_04_24_053517) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,6 +40,7 @@ ActiveRecord::Schema.define(version: 2020_04_21_092625) do
     t.bigint "provider_id"
     t.decimal "long"
     t.decimal "lat"
+    t.string "address"
     t.index ["provider_id"], name: "index_tasks_on_provider_id"
     t.index ["user_id"], name: "index_tasks_on_user_id"
   end
@@ -57,12 +58,8 @@ ActiveRecord::Schema.define(version: 2020_04_21_092625) do
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
     t.string "name"
-    t.string "role"
-    t.string "image"
     t.string "email"
     t.string "address"
-    t.integer "postcode"
-    t.string "city"
     t.json "tokens"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -4,5 +4,8 @@ FactoryBot.define do
     long { '52.15'}
     lat{ '52.15'}
     status {'pending'}
+    name {'Robin'}
+    address {'Bolidenvägen 12'}
+    phone {'0729999999'}
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -25,4 +25,21 @@ RSpec.describe Task, type: :model do
     it { is_expected.to belong_to :user }
     it { is_expected.to belong_to(:provider).optional(true) }
   end
+
+  describe 'check if task has phone/name/adress' do
+    let(:task) { create(:task) }
+    let!(:task_items) { 5.times { create(:task_item, task: task) } }
+
+    it 'expects to contain the product name' do
+      expect(Task.last.name).to eq 'Robin'
+    end
+
+    it 'expects to contain the product price' do
+      expect(Task.last.address).to eq 'Bolidenvägen 12'
+    end
+
+    it 'expects to contain the product name' do
+      expect(Task.last.phone).to eq '0729999999'
+    end
+  end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Task, type: :model do
     it { is_expected.to have_db_column :provider_id }
     it { is_expected.to have_db_column :long }
     it { is_expected.to have_db_column :lat }
+    it { is_expected.to have_db_column :address }
   end
 
   describe 'Validations' do

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe Task, type: :model do
     it { is_expected.to have_db_column :long }
     it { is_expected.to have_db_column :lat }
     it { is_expected.to have_db_column :address }
+    it { is_expected.to have_db_column :name }
+    it { is_expected.to have_db_column :phone }
   end
 
   describe 'Validations' do

--- a/spec/requests/api/v1/authentication/user_can_login_spec.rb
+++ b/spec/requests/api/v1/authentication/user_can_login_spec.rb
@@ -7,9 +7,7 @@ RSpec.describe 'POST /api/v1/auth/sign_in', type: :request do
     {
       'data' => {
         'id' => user.id, 'uid' => user.email, 'email' => user.email,
-        'provider' => 'email', 'allow_password_change' => false,
-        "image"=> nil, "name"=> nil, "postcode"=> nil, "role"=> nil,
-        "address"=> nil, "city"=> nil
+        'provider' => 'email', 'allow_password_change' => false, "name"=> nil, "address"=> nil 
       }
     }
   end


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/172493274)

```
As a person in need
To be able to know where I should deliver the groceries
I would like see that persons address.
```
## Changes proposed in this pull request:
* Adds name to task
* Adds address to task
* Adds phone to task
* Deletes columns not used in our DB.

## What I have learned working on this feature:
* Refreshed knowledge about migrations.

