### PR TITLE
API - User can delete finalized orders.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ The [visitors interface](https://github.com/CraftAcademy/helping_hand_client) an
 # The MVP product
 **The MVP product will include a way for a visitor to:**
 * Users can register and login
-* User can create help request
+* User can create a help request
 * User can claim help requests
 * User can see his profile
-* User can use Google maps with different functionalities.
+* Users can use Google maps with different functionalities.
 
 ## Authors
 | [Jaime](https://github.com/JaimeCrz) | [Robin](https://github.com/robin-lillqvist) | [Carlos](https://github.com/Carltesio) | [Pierre](https://github.com/pierre-1) | [Janko](https://github.com/MadFarmer101) | [Blake](https://github.com/blake-futchi) |

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -60,7 +60,7 @@ class Api::V1::TasksController < ApplicationController
     when 'finalized'
       if @task.is_finalizable?(current_user)
         @task.update(status: params[:activity], user: current_user)
-        render json: { message: 'We are happy that you received your order. Please be in touch if you have any further request.' }
+        render json: { message: "We are happy that you received your order. Please be in touch if you have any further request." }
       else
         render_error_message(@task)
       end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,14 +22,14 @@ class ApplicationController < ActionController::API
     elsif params[:activity] == "claimed"
       message = "The task has already been claimed!"
       request_status = 409
-    elsif params[:activity] == "delivered"
+    elsif params[:activity] == "delivered" && task.status == 'claimed'
       message = "You haven't claimed this task, please contact support."
       request_status = 401
-    elsif task.status != 'delivered'
+    elsif task.status != 'delivered' && params[:activity] == "finalized"
       message = "Please, wait until the request has been delivered."
       request_status = 403
     else
-      message = "We are experiencing internal errors. Please refresh the page and contact support. No activity specified"
+      message = "We are experiencing internal errors. Please refresh the page and contact support. No activity specified."
       request_status = 500
     end
     render json: { error_message: message }, status: request_status

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::API
     elsif task.task_items.count < 5
       message = "You have to pick at least 5 products."
       request_status = 403
-    elsif task.user_id == current_user.id
+    elsif task.user_id == current_user.id && params[:activity] == "claimed"
       message = "You cannot claim your own task."
       request_status = 405
     elsif params[:activity] == "claimed"
@@ -25,6 +25,9 @@ class ApplicationController < ActionController::API
     elsif params[:activity] == "delivered"
       message = "You haven't claimed this task, please contact support."
       request_status = 401
+    elsif task.status != 'delivered'
+      message = "Please, wait until the request has been delivered."
+      request_status = 403
     else
       message = "We are experiencing internal errors. Please refresh the page and contact support. No activity specified"
       request_status = 500
@@ -32,3 +35,4 @@ class ApplicationController < ActionController::API
     render json: { error_message: message }, status: request_status
   end
 end
+

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -21,7 +21,7 @@ class Task < ApplicationRecord
   end
 
   def is_finalizable?(user)
-    status != 'finalized' && self.user == user
+    status == 'delivered' && self.user == user
   end
 
   def is_declinable?(user)

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -29,6 +29,6 @@ class Task < ApplicationRecord
   end
 
   def is_deletable?(user)
-    (status == 'confirmed' || status == 'pending') && self.user == user
+    (status == 'confirmed' || status == 'pending' || status == 'finalized') && self.user == user
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -17,7 +17,7 @@ class Task < ApplicationRecord
   end
 
   def is_deliverable?(user)
-    status != 'delivered' && self.provider == user
+    status == 'claimed' && self.provider == user
   end
 
   def is_finalizable?(user)

--- a/spec/requests/api/v1/provider/deliver_task_spec.rb
+++ b/spec/requests/api/v1/provider/deliver_task_spec.rb
@@ -44,5 +44,25 @@ RSpec.describe "PUT api/v1/tasks/:id", type: :request do
         expect(response_json["error_message"]).to eq "You haven't claimed this task, please contact support."
       end
     end
+
+    describe "Provider tries to deliver task again" do
+
+      let(:another_task) { create(:task, status: "finalized", provider: provider) }
+      let!(:task_items) { 5.times { create(:task_item, task: another_task) } }
+
+      before do
+        put "/api/v1/tasks/#{another_task.id}",
+          params: { activity: "delivered" },
+          headers: provider_headers
+      end
+
+      it "returns a 500 response status" do
+        expect(response).to have_http_status 500
+      end
+
+      it "response with unauthorized message" do
+        expect(response_json["error_message"]).to eq "We are experiencing internal errors. Please refresh the page and contact support. No activity specified."
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/requester/delete_task_spec.rb
+++ b/spec/requests/api/v1/requester/delete_task_spec.rb
@@ -41,6 +41,24 @@ RSpec.describe 'Api::V1::TasksController', type: :request do
         expect(response_json['message']).to eq 'Your request has been successfully deleted.'
       end
     end
+
+    describe 'User can delete his finalized task.' do
+      let!(:task) { create(:task, status: 'finalized', user: user) }
+      let!(:task_items) { 5.times { create(:task_item, task: task) } }
+  
+      before do
+        delete "/api/v1/tasks/#{task.id}",
+         headers: user_headers
+      end
+
+      it 'returns a 200 response status' do
+        expect(response).to have_http_status 200
+      end
+  
+      it 'Requester is able to delete his request.' do
+        expect(response_json['message']).to eq 'Your request has been successfully deleted.'
+      end
+    end
   end
 
   describe 'Unccessessfully' do

--- a/spec/requests/api/v1/requester/finalized_task_spec.rb
+++ b/spec/requests/api/v1/requester/finalized_task_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'PUT api/v1/tasks/:id', type: :request do
       end
 
       it 'response with an error message' do
-        expect(response_json['error_message']).to eq 'We are experiencing internal errors. Please refresh the page and contact support. No activity specified'
+        expect(response_json['error_message']).to eq 'We are experiencing internal errors. Please refresh the page and contact support. No activity specified.'
       end
     end
 
@@ -85,7 +85,7 @@ RSpec.describe 'PUT api/v1/tasks/:id', type: :request do
       end
 
       it 'response with an error message' do
-        expect(response_json['error_message']).to eq 'We are experiencing internal errors. Please refresh the page and contact support. No activity specified'
+        expect(response_json['error_message']).to eq 'We are experiencing internal errors. Please refresh the page and contact support. No activity specified.'
       end
     end
   end

--- a/spec/requests/api/v1/requester/finalized_task_spec.rb
+++ b/spec/requests/api/v1/requester/finalized_task_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe 'PUT api/v1/tasks/:id', type: :request do
   let(:provider_credentials) { provider.create_new_auth_token }
   let(:provider_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(provider_credentials) }
 
-
-  let(:task) { create(:task, status: 'delivered', provider: provider, user: user) }
-  let!(:task_items) { 5.times { create(:task_item, task: task) } }
-
   describe 'Succesfully finalizes the task' do
+
+    let(:task) { create(:task, status: 'delivered', provider: provider, user: user) }
+    let!(:task_items) { 5.times { create(:task_item, task: task) } }
+
     before do
       put "/api/v1/tasks/#{task.id}",
       params: { activity: 'finalized' },
@@ -30,7 +30,30 @@ RSpec.describe 'PUT api/v1/tasks/:id', type: :request do
   end
 
   describe 'Unsuccesfully finalizes the task' do
-    describe 'provider tries to finalize the otder' do
+
+    let(:task) { create(:task, status: 'delivered', provider: provider, user: user) }
+    let!(:task_items) { 5.times { create(:task_item, task: task) } }
+
+    let(:another_task) { create(:task, status: 'confirmed', provider: provider, user: user) }
+    let!(:another_task_items) { 5.times { create(:task_item, task: another_task) } }
+
+    describe 'Requester tries to finalize the order before delivered' do
+      before do
+        put "/api/v1/tasks/#{another_task.id}",
+        params: { activity: 'finalized' },
+        headers: user_headers
+      end
+
+      it 'returns a 403 response status' do
+        expect(response).to have_http_status 403
+      end
+
+      it 'response with an error message' do
+        expect(response_json['error_message']).to eq 'Please, wait until the request has been delivered.'
+      end
+    end
+
+    describe 'provider tries to finalize the order' do
       before do
         put "/api/v1/tasks/#{task.id}",
         params: { activity: 'finalized' },


### PR DESCRIPTION
# [PT Story]

```
As a user
In order to have more space in my profile
I would like to see my personal information.
```
## Changes proposed in this pull request:
* User can delete his finalized order.
* User can only finalize his only when it's delivered.

## What I have learned working on this feature:
* Refreshed knowledge about Rspec && Rails controllers /models.

